### PR TITLE
Change rabl templates to conform with jsonapi

### DIFF
--- a/app/views/academic_careers/index.rabl
+++ b/app/views/academic_careers/index.rabl
@@ -1,2 +1,2 @@
-collection @academic_careers
+collection @academic_careers => :academic_careers
 extends("academic_careers/show")

--- a/app/views/institutions/index.rabl
+++ b/app/views/institutions/index.rabl
@@ -1,2 +1,2 @@
-collection @institutions
+collection @institutions => :institutions
 extends("institutions/show")

--- a/app/views/sessions/index.rabl
+++ b/app/views/sessions/index.rabl
@@ -1,2 +1,2 @@
-collection @sessions
+collection @sessions => :sessions
 extends("sessions/show")

--- a/app/views/terms/index.rabl
+++ b/app/views/terms/index.rabl
@@ -1,2 +1,2 @@
-collection @terms
+collection @terms => :terms
 extends("terms/show")

--- a/spec/requests/get_academic_careers_spec.rb
+++ b/spec/requests/get_academic_careers_spec.rb
@@ -6,19 +6,21 @@ RSpec.describe "Get academic careers" do
     it "returns a non-empty collection" do
       get "/academic_careers.json"
 
-      expect(JSON.parse(response.body)).not_to be_empty
+      academic_careers = JSON.parse(response.body)["academic_careers"]
+      expect(academic_careers).not_to be_empty
     end
 
     it "returns a structure that contains academic careers attributes" do
       get "/academic_careers.json"
 
-      compare_element_to_documentation(JSON.parse(response.body))
+      academic_careers = JSON.parse(response.body)["academic_careers"]
+      compare_element_to_documentation(academic_careers)
     end
 
     it "returns a structure of unique academic_careers" do
       get "/academic_careers.json"
 
-      academic_careers = JSON.parse(response.body)
+      academic_careers = JSON.parse(response.body)["academic_careers"]
       expect(academic_careers).to match(academic_careers.to_set)
     end
   end

--- a/spec/requests/get_institutions_spec.rb
+++ b/spec/requests/get_institutions_spec.rb
@@ -6,19 +6,21 @@ RSpec.describe "Get institutions" do
     it "returns a non-empty collection" do
       get "/institutions.json"
 
-      expect(JSON.parse(response.body)).not_to be_empty
+      institutions = JSON.parse(response.body)["institutions"]
+      expect(institutions).not_to be_empty
     end
 
     it "returns a structure that contains institution attributes" do
       get "/institutions.json"
 
-      compare_element_to_documentation(JSON.parse(response.body))
+      institutions = JSON.parse(response.body)["institutions"]
+      compare_element_to_documentation(institutions)
     end
 
     it "returns a structure of unique institutions" do
       get "/institutions.json"
 
-      institutions = JSON.parse(response.body)
+      institutions = JSON.parse(response.body)["institutions"]
       expect(institutions).to match(institutions.to_set)
     end
   end

--- a/spec/requests/get_sessions_spec.rb
+++ b/spec/requests/get_sessions_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe "Get sessions" do
     it "returns a non-empty collection" do
       get "/sessions.json"
 
-      sessions = JSON.parse(response.body)
-
+      sessions = JSON.parse(response.body)["sessions"]
       expect(sessions).not_to be_empty
     end
 
     it "returns a structure that contains sessions attributes" do
       get "/sessions.json"
 
-      compare_element_to_documentation(JSON.parse(response.body))
+      sessions = JSON.parse(response.body)["sessions"]
+      compare_element_to_documentation(sessions)
     end
 
     it "returns a structure of unique sessions" do
       get "/sessions.json"
 
-      sessions = JSON.parse(response.body)
+      sessions = JSON.parse(response.body)["sessions"]
       expect(sessions).to match(sessions.to_set)
     end
   end

--- a/spec/requests/get_terms_spec.rb
+++ b/spec/requests/get_terms_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe "Get terms" do
     it "returns a non-empty collection" do
       get "/terms.json"
 
-      terms = JSON.parse(response.body)
-
+      terms = JSON.parse(response.body)["terms"]
       expect(terms).not_to be_empty
     end
 
     it "returns a structure that contains term attributes" do
       get "/terms.json"
 
-      compare_element_to_documentation(JSON.parse(response.body))
+      terms = JSON.parse(response.body)["terms"]
+      compare_element_to_documentation(terms)
     end
 
     it "returns a structure of unique terms" do
       get "/terms.json"
 
-      terms = JSON.parse(response.body)
+      terms = JSON.parse(response.body)["terms"]
       expect(terms).to match(terms.to_set)
     end
   end

--- a/spec/requests/search_sessions_spec.rb
+++ b/spec/requests/search_sessions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "search sessions" do
   describe "by institution" do
     it "returns only sessions that match the institution" do
       get "/sessions.json?q=institution_id=UMNTC"
-      sessions = JSON.parse(response.body)
+      sessions = JSON.parse(response.body)["sessions"]
 
       expect(sessions).not_to be_empty
 
@@ -19,7 +19,7 @@ RSpec.describe "search sessions" do
       #You have to encode | as %7C or else Rspec will error
       get "/sessions.json?q=institution_id=UMNTC%7CUMNMO"
 
-      sessions = JSON.parse(response.body)
+      sessions = JSON.parse(response.body)["sessions"]
 
       expect(sessions).not_to be_empty
 
@@ -32,7 +32,7 @@ RSpec.describe "search sessions" do
   describe "by term" do
     it "returns only sessions that match the term" do
       get "/sessions.json?q=term_id=1159"
-      sessions = JSON.parse(response.body)
+      sessions = JSON.parse(response.body)["sessions"]
 
       expect(sessions).not_to be_empty
 
@@ -44,7 +44,7 @@ RSpec.describe "search sessions" do
     it "returns only sessions that match either term" do
       get "/sessions.json?q=term_id=1155%7C1159"
 
-      sessions = JSON.parse(response.body)
+      sessions = JSON.parse(response.body)["sessions"]
 
       expect(sessions).not_to be_empty
 
@@ -58,7 +58,7 @@ RSpec.describe "search sessions" do
     it "returns only sessions that match the academic career" do
       get "/sessions.json?q=academic_career_id=ugrd"
 
-      sessions = JSON.parse(response.body)
+      sessions = JSON.parse(response.body)["sessions"]
 
       expect(sessions).not_to be_empty
 
@@ -70,7 +70,7 @@ RSpec.describe "search sessions" do
     it "returns only sessions that match either academic_career" do
       get "/sessions.json?q=academic_career_id=ugrd%7Claw"
 
-      sessions = JSON.parse(response.body)
+      sessions = JSON.parse(response.body)["sessions"]
 
       expect(sessions).not_to be_empty
 
@@ -83,7 +83,7 @@ RSpec.describe "search sessions" do
   describe "combining searches" do
     it "returns sessions that match all criteria" do
       get "/sessions.json?q=academic_career_id=ugrd%7Claw,term_id=1159,institution_id=UMNTC"
-      sessions = JSON.parse(response.body)
+      sessions = JSON.parse(response.body)["sessions"]
 
       expect(sessions).not_to be_empty
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
@@ -47,8 +49,6 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:


### PR DESCRIPTION
The expected return for for all of the routes is to wrap the whole thing in {} and have a top-level-key of the pluralized resource name (sessions, terms, etc)

```
{
  sessions: [
    {
      type: "session",
      etc
     ...
   }
  ]
}
```

as per jsonapi. The rabl templates were leaving out the plural resource
name at the start and not wrapping the whole thing in a {}.

The result of this is that jquery couldn't get the collection of
resources out correctly with syntax like `response.sessions`.

The small tweaks to the rabl templates are documented here:

https://github.com/nesquena/rabl/wiki/Conforming-to-jsonapi.org-format#resource-collections
