### PR TITLE
Sort sessions by session_code

### DIFF
--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -38,6 +38,8 @@ class DataSource
       sessions.session_code = eff_session_names.fieldvalue
     right join #{Rails.configuration.x.peoplesoft_models_schema}.cs_ps_um_cl_schd_dts schedule_dates on
       sessions.strm = schedule_dates.strm
+    order by
+      session_code
 EOS
 
     sanitized_sql = sanitize_sql(sql)

--- a/spec/requests/search_sessions_spec.rb
+++ b/spec/requests/search_sessions_spec.rb
@@ -92,5 +92,21 @@ RSpec.describe "search sessions" do
       expect(session["term"]["term_id"]).to eq("1159")
       expect(session["institution"]["institution_id"]).to eq("UMNTC")
     end
+
+    it "returns sessions sorted by session_code within a institution and term" do
+      get "/sessions.json"
+      sessions = JSON.parse(response.body)["sessions"]
+      random_session = sessions.sample
+      random_institution_id = random_session["institution"]["institution_id"]
+      random_term_id = random_session["term"]["term_id"]
+      random_career_id = random_session["academic_career"]["academic_career_id"]
+      get "/sessions.json?q=institution_id=#{random_institution_id},term_id=#{random_term_id},academic_career_id=#{random_career_id}"
+      sessions_for_term_and_institution = JSON.parse(response.body)["sessions"]
+
+      expect(sessions_for_term_and_institution).not_to be_empty
+
+      returned_session_codes = sessions_for_term_and_institution.map { |x| x["session_code"] }
+      assert_equal returned_session_codes, returned_session_codes.sort
+    end
   end
 end


### PR DESCRIPTION
Fixes #19

The sort was pretty straightforward. Testing is a bit odd. The main
(only?) client of this code only cares about sessions in the context of
a term/institution/career. So the test ensures that results in that
context are ordered correctly.

But, more generally, this change means that if you go to `sessions.json`
without any filters, the results will be sorted by the session code,
which might be a little strange. I don't think it's a big problem, since
the usage of this service is so small.