### PR TITLE
Sort returned data

### DIFF
--- a/app/models/academic_career.rb
+++ b/app/models/academic_career.rb
@@ -20,7 +20,6 @@ class AcademicCareer
   alias_method :eql?, :==
 
   def self.all
-    AcademicCareerSource.all
+    AcademicCareerSource.all.sort_by(&:academic_career_id)
   end
-
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -24,7 +24,6 @@ class Institution
   alias_method :eql?, :==
 
   def self.all
-    InstitutionSource.all
+    InstitutionSource.all.sort_by(&:abbreviation)
   end
-
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -33,6 +33,6 @@ class Session
   alias_method :eql?, :==
 
   def self.all
-    SessionSource.all
+    SessionSource.all.sort_by(&:session_code)
   end
 end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -24,6 +24,6 @@ class Term
   alias_method :eql?, :==
 
   def self.all
-    TermSource.all
+    TermSource.all.sort_by(&:strm)
   end
 end


### PR DESCRIPTION
Requested by Sarah in INC1466846

> ... I see that the list of dropdown items for all three
> search options (term, institution, and career) are not in numerical or
> alphabetical order. * It would be helpful, especially for the term
> dropdown, if they were in numerical/alpha order. *