### PR TITLE
Update query to get correct session same

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -8,7 +8,7 @@ class Session
     self.institution = Institution.new(attributes)
     self.term = Term.new(attributes)
     self.session_code = attributes["session_code"]
-    self.session_name = attributes["xlatlongname"]
+    self.session_name = attributes["session_name"]
     self.begin_date = attributes["sess_begin_dt"].strftime("%F")
     self.end_date = attributes["sess_end_dt"].strftime("%F")
     self.enrollment_open_date = attributes["enroll_open_dt"].strftime("%F")


### PR DESCRIPTION
[Finishes #144131435]

The query that found effective sessions names was incorrect, thanks to
its grouping. This commit updates the query to follow our normal
approach for writing effective-dated queries.

While I was in there I changed some other aspects of this query

Removed the join to cs_ps_um_cl_schd_dts
----

Data from this table was never used. And I'm not sure why it was a right
join, since if data was only in that table but not any of the other
tables then that would be a serious problem.

Changed join on session names from Left to Inner
----

A missing session name (if it ever happened) would be a problem within
PeopleSoft itself. We can inner join safely.

Renamed the session_name column from xlatlongname
----

Because `xlatlongname` is a terrible name.

Added table prefixes for everything the data source selects.
----

Makes it easier to see where the data is coming from.