### PR TITLE
Add and setup logrotate

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,6 +5,8 @@ require 'capistrano/setup'
 require 'capistrano/deploy'
 require 'capistrano/bundler'
 require 'capistrano/passenger'
+require "capistrano/logrotate"
+
 # Include tasks from other gems included in your Gemfile
 #
 # For documentation on these, see for example:

--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,6 @@ group :development do
   gem 'capistrano', '~> 3.6.0'
   gem 'capistrano-rails', '~> 1.2.0'
   gem 'capistrano-bundler', '~> 1.2.0'
+  gem "capistrano-logrotate", "0.4.0"
   gem 'capistrano-passenger', '~> 0.2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       capistrano (~> 3.1)
       sshkit (~> 1.2)
     capistrano-harrow (0.5.3)
+    capistrano-logrotate (0.4.0)
+      capistrano (~> 3.0)
     capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
     capistrano-rails (1.2.2)
@@ -160,6 +162,7 @@ DEPENDENCIES
   activerecord-oracle_enhanced-adapter (~> 1.6)
   capistrano (~> 3.6.0)
   capistrano-bundler (~> 1.2.0)
+  capistrano-logrotate (= 0.4.0)
   capistrano-passenger (~> 0.2.0)
   capistrano-rails (~> 1.2.0)
   lastpassify

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,3 +19,21 @@ set :ssh_options,
     user: fetch(:user),
     forward_agent: true,
     auth_methods: %w(publickey)
+
+set :role, :web
+set :logrotate_role, :web
+set :logrotate_conf_path, -> { File.join('/swadm/etc', 'logrotate.d', "#{fetch(:application)}_#{fetch(:stage)}") }
+set :logrotate_log_path, -> { File.join(shared_path, 'log') }
+
+namespace :deploy do
+  desc 'Restart application'
+  task :restart do
+    on roles(:app), in: :sequence, wait: 5 do
+      # Your restart mechanism here, for example:
+      execute :touch, release_path.join('tmp/restart.txt')
+    end
+  end
+
+  after :publishing, :restart
+  after :published, 'logrotate:config'
+end


### PR DESCRIPTION
The logrotate role was added to the Sessions web service servers and
deployed in https://github.umn.edu/asrweb/asr_ansible/pull/442

- adds the capistrano-logrotate gem (v0.4.0 because not all releases
have been stable)
- adds the "capistrano/logrotate" task to the Capfile
- adds a `:deploy` task and configures rotating logs in config/deploy.rb
with Capistrano

Fixes #31.