### PR TITLE
Update Readme with new structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,23 +48,17 @@ Just seperate your criteria with commas
 You will get a collection of `session` resources back. The format will depend on if you choose XML or JSON, but the data will be like this example:
 
 ```yaml
-session:
-  type: 'session'
-  session_id: 'umntc_ugrd_1159_017'
-  academic_career:
-    type: 'academic_career'
-    academic_career_id: 'ugrd'
-  institution:
-    type: 'institution'
-    institution_id: 'umntc'
-    abbreviation: 'umntc'
-  term:
-    type: 'term'
-    term_id: '1159'
-    strm: '1159'
-  session_code: '017'
-  session_name: '11 wk Session'
-  begin_date: '2015-09-08'
-  end_date: '2015-11-23'
-  enrollement_open_date: '2015-05-01'
+data:
+  -
+    type: 'session'
+    id: 'umntc_ugrd_1159_017'
+    attributes:
+      academic_career: 'ugrd'
+      institution: 'umntc'
+      term: '1159'
+      session_code: '017'
+      session_name: '11 wk Session'
+      begin_date: '2015-09-08'
+      end_date: '2015-11-23'
+      enrollement_open_date: '2015-05-01'
 ```


### PR DESCRIPTION
In order to update the sessions API to the JSON standard according to
[jsonapi.org](https://jsonapi.org/), we are proposing changing the structure of the JSON
returned. We think this brings it into compliance. There are nested
objects we are removing, but if there is a reason we should keep them we
can. We think removing them would simplify parsing the response.

Co-authored-by: Brittany Greaner <grea0022@umn.edu>
Co-authored-by: Sierra Schultz <schu3450@umn.edu>
Co-authored-by: Tony Thomas <thoma127@umn.edu>