### PR TITLE
Use select_all instead of find_by_sql

### DIFF
--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -1,4 +1,3 @@
-require "ostruct"
 
 class DataSource
 
@@ -15,10 +14,6 @@ class DataSource
 
   def self.table_name
     "dummy_table_for_active_record"
-  end
-
-  def self.attribute_types
-    OpenStruct.new(:each_key => [])
   end
 
   def self.all
@@ -70,6 +65,7 @@ class DataSource
 EOS
 
     sanitized_sql = sanitize_sql(sql)
-    find_by_sql(sanitized_sql).to_set
+    result_set = connection.select_all(sanitized_sql)
+    result_set.map { |record| instantiate(record, []) }.uniq
   end
 end

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -1,4 +1,5 @@
 
+# The base class used to query data models
 class DataSource
 
   include ActiveRecord::Sanitization
@@ -23,14 +24,14 @@ class DataSource
         all_items.fieldvalue,
         all_items.xlatlongname as session_name
       FROM
-          #{Rails.configuration.x.peoplesoft_models_schema}.cs_psxlatitem all_items
+          #{peoplesoft_models_schema}.cs_psxlatitem all_items
       INNER JOIN (
           SELECT
               fieldname,
               fieldvalue,
               max(effdt) as effdt
           FROM
-              #{Rails.configuration.x.peoplesoft_models_schema}.cs_psxlatitem
+              #{peoplesoft_models_schema}.cs_psxlatitem
           WHERE
               effdt <= sysdate
           GROUP BY
@@ -52,13 +53,13 @@ class DataSource
       sessions.sess_end_dt,
       sessions.enroll_open_dt
     FROM
-      #{Rails.configuration.x.peoplesoft_models_schema}.cs_ps_session_tbl sessions
+      #{peoplesoft_models_schema}.cs_ps_session_tbl sessions
     INNER JOIN
-      #{Rails.configuration.x.peoplesoft_models_schema}.eff_session_names ON
+      #{peoplesoft_models_schema}.eff_session_names ON
       sessions.session_code = eff_session_names.fieldvalue
     INNER JOIN
       -- Restricts the terms returned to just those that can can be scheduled
-      #{Rails.configuration.x.peoplesoft_models_schema}.cs_ps_um_cl_schd_dts terms_allowed_to_be_scheduled ON
+      #{peoplesoft_models_schema}.cs_ps_um_cl_schd_dts terms_allowed_to_be_scheduled ON
       sessions.strm = terms_allowed_to_be_scheduled.strm
     ORDER BY
       session_code
@@ -67,5 +68,12 @@ EOS
     sanitized_sql = sanitize_sql(sql)
     result_set = connection.select_all(sanitized_sql)
     result_set.map { |record| instantiate(record, []) }.uniq
+  end
+
+  private
+
+  # :reek:UtilityFunction
+  def self.peoplesoft_models_schema
+    Rails.configuration.x.peoplesoft_models_schema
   end
 end


### PR DESCRIPTION
Fixes #57.

## Use select_all instead of find_by_sql (e849419116f1d2d5c337c54e22329334371670d4)
See details in #57. The only thing I needed to change from Davin's suggestion is that we need to return unique values.

---

## Address Reek concerns (e167dd600192995f59fbdc23ee41cbbe8761367f)
Reek flagged duplicate method calls for this class. I created a private
method which Reek then flagged as a utility function. At least this way
we only have to disable Reek in one place.