### PR TITLE
Update to Ruby 3.2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: ~/.rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 3.0
 
 Rails:
   Enabled: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /lpass
 RUN export PATH="/usr/bin:$PATH" && export OPENSSL_ROOT_DIR=/usr/bin && export CFLAGS="-fcommon" && cd /etc/lastpass-cli && PREFIX=/lpass make && PREFIX=/lpass make install
 
 # Build main image based off an image we have already created
-FROM asr-docker-local.artifactory.umn.edu/ruby_2_7_oracle:0.0.1 as sessions
+FROM asr-docker-local.artifactory.umn.edu/ruby_3_2_2_node_18_oracle:0.0.2 as sessions
 ARG BUNDLER_VERSION="2.3.26"
 
 COPY --from=lpass_builder /lpass/bin/lpass /usr/bin/lpass

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development do
   gem "capistrano-bundler", "~> 1.2.0"
   gem "capistrano-logrotate", "0.4.0"
   gem "capistrano-passenger", "~> 0.2.0"
-  gem "reek", "~> 5.0"
+  gem "reek", "~> 6.1"
+  gem "rubocop-ast", "~> 1.30"
   gem "standard"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://artifactory.umn.edu/artifactory/api/gems/asr-rubygems"
-ruby "2.7.8"
+ruby "3.2.2"
 
 gem "rails", "~> 6.1.7.6"
 
@@ -20,6 +20,7 @@ group :development, :test do
   gem "listen"
   gem "spring", "~> 1.3.6"
   gem "oracle_cleaner"
+  gem "puma", "~> 5.2"
   gem "rspec-rails", "~> 6.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,6 @@ GEM
     capistrano-rails (1.2.3)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    codeclimate-engine-rb (0.4.2)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -146,9 +145,9 @@ GEM
     oj (2.18.5)
     oracle_cleaner (0.1.0)
     parallel (1.23.0)
-    parser (2.7.2.0)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
-    psych (3.1.0)
+      racc
     puma (5.6.7)
       nio4r (~> 2.0)
     query_string_search (0.0.7)
@@ -192,11 +191,9 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    reek (5.6.0)
-      codeclimate-engine-rb (~> 0.4.0)
+    reek (6.1.4)
       kwalify (~> 0.7.0)
-      parser (>= 2.5.0.0, < 2.8, != 2.5.1.1)
-      psych (~> 3.1.0)
+      parser (~> 3.2.0)
       rainbow (>= 2.0, < 4.0)
     regexp_parser (2.8.2)
     request_store (1.5.1)
@@ -228,8 +225,8 @@ GEM
       rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
     rubocop-performance (1.9.2)
       rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -285,14 +282,15 @@ DEPENDENCIES
   rabl (~> 0.16)
   rack-cors (~> 1.1.1)
   rails (~> 6.1.7.6)
-  reek (~> 5.0)
+  reek (~> 6.1)
   rspec-rails (~> 6.0)
+  rubocop-ast (~> 1.30)
   ruby-oci8 (~> 2.2)
   spring (~> 1.3.6)
   standard
 
 RUBY VERSION
-   ruby 3.0.4p208
+   ruby 3.2.2p53
 
 BUNDLED WITH
    2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     psych (3.1.0)
+    puma (5.6.7)
+      nio4r (~> 2.0)
     query_string_search (0.0.7)
     rabl (0.16.1)
       activesupport (>= 2.3.14)
@@ -278,6 +280,7 @@ DEPENDENCIES
   loofah (~> 2.19.1)
   oj (~> 2.18.0)
   oracle_cleaner
+  puma (~> 5.2)
   query_string_search (~> 0.0.7)
   rabl (~> 0.16)
   rack-cors (~> 1.1.1)
@@ -289,7 +292,7 @@ DEPENDENCIES
   standard
 
 RUBY VERSION
-   ruby 2.7.8p225
+   ruby 3.0.4p208
 
 BUNDLED WITH
-   2.1.4
+   2.3.26

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,8 +68,6 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  config.x.peoplesoft_models_schema = "asr_warehouse_esup"
-
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,8 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
+  config.x.peoplesoft_models_schema = "asr_warehouse_esup"
+
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter

--- a/script/_lint.sh
+++ b/script/_lint.sh
@@ -7,14 +7,10 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-RED="\033[0;31m"
-NC='\033[0m' # No Color
-
 if [ "$LINT_ALL" = "true" ]; then
   git config --global http.proxy http://kraken02.oit.umn.edu:3128
   git config --global https.proxy https://kraken02.oit.umn.edu:3128
   echo "==> Checking Gems..."
-  echo "==> ${RED}NOTE: Several CVES are being ignored in .bundler-audit.yml. Remove them once we've upgraded Rails.${NC}"
   bundle audit check --update
   echo "==> Running Brakeman..."
   brakeman
@@ -24,7 +20,6 @@ if [ "$LINT_ALL" = "true" ]; then
   standardrb --no-fix
 else
   echo "==> Checking Gems..."
-  echo "==> ${RED}NOTE: Several CVES are being ignored in .bundler-audit.yml. Remove them once we've upgraded Rails.${NC}"
   bundle audit check --update
   echo "==> Running Reek..."
   reek $(git diff --name-only --ignore-submodules=all --cached) --force-exclusion


### PR DESCRIPTION
* Update to a container running ruby 3.2.2 72d7bd5790ca29161ab19dda445d18d26efe86f8
    * I ran the tests on an interim Ruby 3.0 container and everything passed so I went straight to 3.2.2
* Remove warning about ignored CVEs 85e0707c3ebc7ca9c7e9a04203bb2372694a33ca
* Update reek and rubocop-ast 079077089f25ef82a1942dfb6953bcfbe3baa512
    * Update reek (why not?)
    * Update rubocop-ast

The rubocop-ast gem is a dependency of Rubocop which is a dependency of
Standard. I was getting a `RuboCop found unknown Ruby version: 3.2
(ArgumentError)` after switching to Ruby 3.2. Updating that gem resolved
the error.