### PR TITLE
Use Lastpass container during setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,6 @@
 # Build Lastpass CLI in separate build container
-FROM gcc:13 AS lpass_builder
-ARG LASTPASS_VERSION="1.3.6"
-
-RUN apt-get --allow-releaseinfo-change update && \
-    apt-get --no-install-recommends -yqq install \
-    bash-completion \
-    build-essential \
-    cmake \
-    libcurl4  \
-    libcurl4-openssl-dev  \
-    libssl-dev  \
-    libxml2 \
-    libxml2-dev  \
-    pkg-config \
-    ca-certificates \
-    xclip
-RUN mkdir -p /etc/lastpass-cli && cd /etc/lastpass-cli
-
-# Download and extract lastpass-cli
-RUN curl -fsSL https://github.com/lastpass/lastpass-cli/archive/v$LASTPASS_VERSION.tar.gz -o lastpass-cli.tar.gz
-RUN tar -xzf lastpass-cli.tar.gz -C /etc/lastpass-cli --strip-components 1
-
-RUN mkdir -p /lpass
-
-RUN export PATH="/usr/bin:$PATH" && export OPENSSL_ROOT_DIR=/usr/bin && export CFLAGS="-fcommon" && cd /etc/lastpass-cli && PREFIX=/lpass make && PREFIX=/lpass make install
-
-# Build main image based off an image we have already created
 FROM asr-docker-local.artifactory.umn.edu/ruby_3_2_2_node_18_oracle:0.0.2 as sessions
 ARG BUNDLER_VERSION="2.3.26"
-
-COPY --from=lpass_builder /lpass/bin/lpass /usr/bin/lpass
 
 WORKDIR /app
 

--- a/script/_lastpassify
+++ b/script/_lastpassify
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# script/lastpassify create DB credentials using the lastpass Docker container
+
+set -e
+
+docker run \
+  -it --rm \
+  -e LASTPASS_USERNAME=$(whoami) \
+  -v "$(pwd):/workdir" \
+  asrcustomsolutions/lastpass:latest \
+  lastpassify

--- a/script/setup
+++ b/script/setup
@@ -7,15 +7,16 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+echo "==> Pulling lastpass container"
+docker pull asrcustomsolutions/lastpass:latest
+
+echo "==> Running lpassify"
+script/_lastpassify
+
 echo "==> Checking architecture"
 if [ `uname -m` = "arm64" ]; then
   echo "====> arm64 architecture detected"
   cp docker-compose.arm64.yml docker-compose.yml
-
-  echo "==> Setting up lastpass passwords for arm64"
-  source ~/.asr/functions/lastpass_config_helper.sh > /dev/null 2>&1
-  echo "==> Running lpassify"
-  echo `lpassify`
 else
   echo "====> x86 architecture detected"
   cp docker-compose.x86.yml docker-compose.yml


### PR DESCRIPTION
Finishes PT [#186327125](https://www.pivotaltracker.com/story/show/186327125)

Update scripts to set up database credentials using the new Lastpass container.

With this change, we don't need to worry about building the Lastpass cli inside the web container and setup goes much faster.