### PR TITLE
Add formatter configuration

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,11 @@
+fix: true
+parallel: true
+default_ignores: true
+
+ignore:
+  - 'spec/rails_helper.rb'
+  - '**/Gemfile'
+  - 'bundle/**/*'
+  - 'site/**/*.rb'
+  - 'Rakefile'
+  - '**/*.rake'


### PR DESCRIPTION
This PR adds a `.standard.yml` file so that the formatter doesn't try to process the bundler directory or other files where formatting doesn't apply.