### PR TITLE
Add health check endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,10 @@
+# Controller for health checks
+class HealthController < ActionController::Base
+  def show
+    if HealthCheck.healthy?
+      head :ok
+    else
+      head :service_unavailable
+    end
+  end
+end

--- a/app/models/health_check.rb
+++ b/app/models/health_check.rb
@@ -1,0 +1,15 @@
+# :reek:UtilityFunction
+
+# Model for application health checks
+class HealthCheck
+  def self.healthy?
+    new.healthy?
+  end
+
+  def healthy?(sql: "SELECT 'ready' FROM DUAL")
+    result = ActiveRecord::Base.connection.select_value(sql)
+    result == "ready"
+  rescue
+    false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get "/", to: redirect("http://umn-asr.github.io/sessions_data_service/")
+  get "/up", to: "health#show"
 
   resources :terms, only: [:index]
   resources :institutions, only: [:index]

--- a/spec/controllers/health_controller_spect.rb
+++ b/spec/controllers/health_controller_spect.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe HealthController, type: :request do
+  describe "show" do
+    it "returns ok when healthy" do
+      allow(HealthCheck).to receive(:healthy?).and_return(true)
+
+      get "/up"
+      expect(response.status).to eq(200)
+    end
+
+    it "returns service_unavailable when not" do
+      allow(HealthCheck).to receive(:healthy?).and_return(false)
+
+      get "/up"
+      expect(response.status).to eq(503)
+    end
+  end
+end


### PR DESCRIPTION
This PR implements Pivotal Tracker item [#186558072](https://www.pivotaltracker.com/story/show/186558072) - Add health check to Sessions.

We are adding a simple healthcheck endpoint in preparation for containterized deployment.