### PR TITLE
Integrate maintenance mode

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -13,6 +13,7 @@ servers:
       traefik.docker.network: "traefik"
       traefik.http.routers.sessions-web.tls: true
       traefik.http.routers.sessions-web.tls.certresolver: "sectigo"
+      traefik.http.routers.sessions-web.middlewares: "maintenance-mode@file"
     options:
       init: true
       network: "traefik"


### PR DESCRIPTION
This PR partially implements Pivotal Tracker item [#187491415](https://www.pivotaltracker.com/story/show/187491415) - Integrate Traefik Maintenance Middleware into RHEL7 Traefik Services. It adds support for the maintenance mode middleware to Sessions API.