### PR TITLE
Migrate to RHEL9 Servers

### DIFF
--- a/.env.production.erb
+++ b/.env.production.erb
@@ -5,4 +5,3 @@ DATABASE_NAME=<%= `lpass show --field="Database" "Shared-Applications/sessions/o
 DATABASE_USER=<%= `lpass show --username "Shared-Applications/sessions/oracle_production"`.chomp %>
 DATABASE_PASSWORD=<%= `lpass show --password "Shared-Applications/sessions/oracle_production"`.chomp %>
 SECRET_KEY_BASE=<%= `lpass show --field="Secret Key Base" "Shared-Applications/sessions/rails_production"`.chomp %>
-WEB_HOST=<%= `lpass show --field="Web Host" "Shared-Applications/sessions/rails_production"`.chomp %>

--- a/.env.staging.erb
+++ b/.env.staging.erb
@@ -5,4 +5,3 @@ DATABASE_NAME=<%= `lpass show --field="Database" "Shared-Applications/sessions/o
 DATABASE_USER=<%= `lpass show --username "Shared-Applications/sessions/oracle_staging"`.chomp %>
 DATABASE_PASSWORD=<%= `lpass show --password "Shared-Applications/sessions/oracle_staging"`.chomp %>
 SECRET_KEY_BASE=<%= `lpass show --field="Secret Key Base" "Shared-Applications/sessions/rails_staging"`.chomp %>
-WEB_HOST=<%= `lpass show --field="Web Host" "Shared-Applications/sessions/rails_staging"`.chomp %>

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -1,9 +1,9 @@
 servers:
   web:
     hosts:
-      - <%= ENV["WEB_HOST"] %>
+      - asr-container-prd-web-public-01.oit.umn.edu
     labels:
-      traefik.http.routers.sessions-web.rule: Host(`sessions.umn.edu`) || Host(`sessions.prd.asr.umn.edu`)
+      traefik.http.routers.sessions-web.rule: Host(`sessions.umn.edu`) || Host(`sessions.asr-container-prd-web-public-01.asr.umn.edu`)
 
 env:
   clear:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -1,9 +1,9 @@
 servers:
   web:
     hosts:
-      - <%= ENV["WEB_HOST"] %>
+      - asr-container-tst-web-public-01.oit.umn.edu
     labels:
-      traefik.http.routers.sessions-web.rule: Host(`sessions-staging.umn.edu`) || Host(`sessions.qat.asr.umn.edu`)
+      traefik.http.routers.sessions-web.rule: Host(`sessions-staging.umn.edu`) || Host(`sessions.asr-container-tst-web-public-01.asr.umn.edu`)
 
 env:
   clear:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -38,31 +38,27 @@ env:
 
 # Use a different ssh user than root
 ssh:
-  user: swadm
+  user: sessions
 
 # Configure builder setup.
 builder:
   dockerfile: Dockerfile.prod
-  multiarch: false
+  remote:
+    arch: amd64
   args:
+    GID: 3002
     GIT_COMMIT: <%= %x(git rev-parse --short --verify HEAD) %>
-
+    UID: 3002
 
 # Configure a custom healthcheck (default is /up on port 3000)
 healthcheck:
   path: /up
-  port: 3000
   max_attempts: 15
-  interval: 30s
+  interval: 20s
 
-# Bridge fingerprinted assets, like JS and CSS, between versions to avoid
-# hitting 404 on in-flight requests. Combines all files from new and old
-# version inside the asset_path.
-# asset_path: /rails/public/assets
-
-# Configure rolling deploys by setting a wait time between batches of restarts.
-# boot:
-#   limit: 10 # Can also specify as a percentage of total hosts, such as "25%"
-#   wait: 2
-
-run_directory: /swadm/traefik2/conf/dynamic/kamal
+# Configure the role used to determine the primary_host. This host takes
+# deploy locks, runs health checks during the deploy, and follow logs, etc.
+#
+# Caution: there's no support for role renaming yet, so be careful to cleanup
+#          the previous role on the deployed hosts.
+primary_role: web

--- a/script/deploy
+++ b/script/deploy
@@ -4,7 +4,7 @@
 
 set -e
 
-KAMAL_VERSION="1.0.0"
+KAMAL_VERSION="1.8.1"
 
 cd "$(dirname "$0")/.."
 
@@ -32,10 +32,8 @@ docker run -it --rm \
   env push --destination="$1"
 
 # deploy using Kamal
-source ".env.$1"
 docker run -it --rm \
   -e DOCKER_DEFAULT_PLATFORM="linux/amd64" \
-  -e WEBHOST=$WEB_HOST \
   -v "$(pwd):/workdir" \
   -v "$HOME/.ssh:/root/.ssh" \
   -v "/var/run/docker.sock:/var/run/docker.sock" \


### PR DESCRIPTION
This PR updates the project for deployment to our RHEL9 staging and production servers. It contains the following changes:

* Deployment has been updated to use Kamal v1.8.1
* The Kamal configuration has been updated as follows:
  - The SSH user now uses our application specific deployment user
  - The UID/GID for the running container uses our application specific service user
  - The health check interval was updated to once every 20 seconds. This is our current RHEL9 standard.
  - The staging/production servers are no longer pointing to Conflux (RHEL7) but our new shared container environment (RHEL9)
  - The deployment configuration was modified for compatibility with newer versions of Kamal
  - The `WEB_HOST` environment variable was removed because keeping the CNAME a secret wasn't necessary for a publicly accessible API