### PR TITLE
Revert "Wrap env variables in quotes"

### DIFF
--- a/.env.production.erb
+++ b/.env.production.erb
@@ -1,7 +1,7 @@
-ARTIFACTORY_API_KEY="<%= `lpass show --password "asr_dev_user/artifactory_api_key"`.chomp %>"
-ARTIFACTORY_USERNAME="<%= `lpass show --username "asr_dev_user/artifactory_api_key"`.chomp %>"
-DATABASE_HOST="<%= `lpass show --field="Hostname" "Shared-Applications/sessions/oracle_production"`.chomp %>"
-DATABASE_NAME="<%= `lpass show --field="Database" "Shared-Applications/sessions/oracle_production"`.chomp %>"
-DATABASE_USER="<%= `lpass show --username "Shared-Applications/sessions/oracle_production"`.chomp %>"
-DATABASE_PASSWORD="<%= `lpass show --password "Shared-Applications/sessions/oracle_production"`.chomp %>"
-SECRET_KEY_BASE="<%= `lpass show --field="Secret Key Base" "Shared-Applications/sessions/rails_production"`.chomp %>"
+ARTIFACTORY_API_KEY=<%= `lpass show --password "asr_dev_user/artifactory_api_key"`.chomp %>
+ARTIFACTORY_USERNAME=<%= `lpass show --username "asr_dev_user/artifactory_api_key"`.chomp %>
+DATABASE_HOST=<%= `lpass show --field="Hostname" "Shared-Applications/sessions/oracle_production"`.chomp %>
+DATABASE_NAME=<%= `lpass show --field="Database" "Shared-Applications/sessions/oracle_production"`.chomp %>
+DATABASE_USER=<%= `lpass show --username "Shared-Applications/sessions/oracle_production"`.chomp %>
+DATABASE_PASSWORD=<%= `lpass show --password "Shared-Applications/sessions/oracle_production"`.chomp %>
+SECRET_KEY_BASE=<%= `lpass show --field="Secret Key Base" "Shared-Applications/sessions/rails_production"`.chomp %>

--- a/.env.staging.erb
+++ b/.env.staging.erb
@@ -1,7 +1,7 @@
-ARTIFACTORY_API_KEY="<%= `lpass show --password "asr_dev_user/artifactory_api_key"`.chomp %>"
-ARTIFACTORY_USERNAME="<%= `lpass show --username "asr_dev_user/artifactory_api_key"`.chomp %>"
-DATABASE_HOST="<%= `lpass show --field="Hostname" "Shared-Applications/sessions/oracle_staging"`.chomp %>"
-DATABASE_NAME="<%= `lpass show --field="Database" "Shared-Applications/sessions/oracle_staging"`.chomp %>"
-DATABASE_USER="<%= `lpass show --username "Shared-Applications/sessions/oracle_staging"`.chomp %>"
-DATABASE_PASSWORD="<%= `lpass show --password "Shared-Applications/sessions/oracle_staging"`.chomp %>"
-SECRET_KEY_BASE="<%= `lpass show --field="Secret Key Base" "Shared-Applications/sessions/rails_staging"`.chomp %>"
+ARTIFACTORY_API_KEY=<%= `lpass show --password "asr_dev_user/artifactory_api_key"`.chomp %>
+ARTIFACTORY_USERNAME=<%= `lpass show --username "asr_dev_user/artifactory_api_key"`.chomp %>
+DATABASE_HOST=<%= `lpass show --field="Hostname" "Shared-Applications/sessions/oracle_staging"`.chomp %>
+DATABASE_NAME=<%= `lpass show --field="Database" "Shared-Applications/sessions/oracle_staging"`.chomp %>
+DATABASE_USER=<%= `lpass show --username "Shared-Applications/sessions/oracle_staging"`.chomp %>
+DATABASE_PASSWORD=<%= `lpass show --password "Shared-Applications/sessions/oracle_staging"`.chomp %>
+SECRET_KEY_BASE=<%= `lpass show --field="Secret Key Base" "Shared-Applications/sessions/rails_staging"`.chomp %>


### PR DESCRIPTION
Reverts umn-asr/sessions_data_service#79

The quotes were added incorrectly. A new pull request will be opened to fix this.