### PR TITLE
Refactor Kamal to use SSH agent forwarding

### DIFF
--- a/script/_kamal
+++ b/script/_kamal
@@ -1,0 +1,13 @@
+# Kamal helper function for Bash
+
+KAMAL_VERSION="1.9.2"
+
+function kamal() {
+  docker run -it --rm \
+    -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" \
+    -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" \
+    -v "${PWD}:/workdir" \
+    -v "kamal_ssh_data:/root/.ssh" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    ghcr.io/basecamp/kamal:v$KAMAL_VERSION "$@"
+}

--- a/script/deploy
+++ b/script/deploy
@@ -4,8 +4,6 @@
 
 set -e
 
-KAMAL_VERSION="1.8.1"
-
 cd "$(dirname "$0")/.."
 
 if [ $# -eq 0 ]; then
@@ -24,18 +22,8 @@ docker run \
   ./script/_populate_env "$1"
 
 # push the latest environment variables using Kamal
-docker run -it --rm \
-  -v "$(pwd):/workdir" \
-  -v "$HOME/.ssh:/root/.ssh" \
-  -v "/var/run/docker.sock:/var/run/docker.sock" \
-  ghcr.io/basecamp/kamal:v$KAMAL_VERSION \
-  env push --destination="$1"
+source "./script/_kamal"
+kamal env push --destination="$1"
 
 # deploy using Kamal
-docker run -it --rm \
-  -e DOCKER_DEFAULT_PLATFORM="linux/amd64" \
-  -v "$(pwd):/workdir" \
-  -v "$HOME/.ssh:/root/.ssh" \
-  -v "/var/run/docker.sock:/var/run/docker.sock" \
-  ghcr.io/basecamp/kamal:v$KAMAL_VERSION \
-  deploy --destination="$1"
+kamal deploy --destination="$1"


### PR DESCRIPTION
This PR refactors calls to [Kamal](https://kamal-deploy.org/) to use [SSH agent forwarding](https://docs.docker.com/desktop/features/networking/#ssh-agent-forwarding). This is the preferred method of using SSH within the Kamal container because it allows you to use a password protected SSH key and macOS specific SSH configuration.

See the following Knowledgebucket article for more information on how to configure your local development environment to successfully mount the SSH agent socket inside containers: https://github.com/umn-asr/knowledgebucket/blob/main/devops/ssh_configuration.md

This PR also upgrades Kamal to v1.9.2.