### PR TITLE
CVE updates for nokogiri, rack, net-imap, thor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,11 +135,11 @@ GEM
       net-smtp
     marcel (1.0.4)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minitest (5.25.2)
     msgpack (1.7.2)
     mutex_m (0.3.0)
-    net-imap (0.5.2)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -149,7 +149,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.17.2)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oj (2.18.5)
@@ -167,7 +167,7 @@ GEM
     rabl (0.17.0)
       activesupport (>= 2.3.14)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.17)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-session (1.0.2)
@@ -275,7 +275,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.19.1)
     stringio (3.1.2)
-    thor (1.3.2)
+    thor (1.4.0)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
Name: net-imap
Version: 0.5.2
CVE: CVE-2025-25186
GHSA: GHSA-7fc5-f82f-cx69
Criticality: Medium
URL: https://github.com/ruby/net-imap/security/advisories/GHSA-7fc5-f82f-cx69
Title: Possible DoS by memory exhaustion in net-imap
Solution: upgrade to '~> 0.3.8', '~> 0.4.19', '>= 0.5.6'

Name: net-imap
Version: 0.5.2
CVE: CVE-2025-43857
GHSA: GHSA-j3g3-5qv5-52mj
Criticality: Unknown
URL: https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
Title: net-imap rubygem vulnerable to possible DoS by memory exhaustion
Solution: upgrade to '~> 0.2.5', '~> 0.3.9', '~> 0.4.20', '>= 0.5.7'

Name: nokogiri
Version: 1.17.2
GHSA: GHSA-353f-x4gh-cqq8
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-353f-x4gh-cqq8
Title: Nokogiri patches vendored libxml2 to resolve multiple CVEs
Solution: upgrade to '>= 1.18.9'

Name: nokogiri
Version: 1.17.2
GHSA: GHSA-5w6v-399v-w3cc
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-5w6v-399v-w3cc
Title: Nokogiri updates packaged libxml2 to v2.13.8 to resolve CVE-2025-32414 and CVE-2025-32415
Solution: upgrade to '>= 1.18.8'

Name: nokogiri
Version: 1.17.2
GHSA: GHSA-mrxw-mxhj-p664
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-mrxw-mxhj-p664
Title: Nokogiri updates packaged libxslt to v1.1.43 to resolve multiple CVEs
Solution: upgrade to '>= 1.18.4'

Name: nokogiri
Version: 1.17.2
GHSA: GHSA-vvfq-8hwr-qm4m
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vvfq-8hwr-qm4m
Title: Nokogiri updates packaged libxml2 to 2.13.6 to resolve CVE-2025-24928 and CVE-2024-56171
Solution: upgrade to '>= 1.18.3'

Name: rack
Version: 2.2.10
CVE: CVE-2025-25184
GHSA: GHSA-7g2v-jj9q-g3rg
Criticality: Unknown
URL: https://github.com/rack/rack/security/advisories/GHSA-7g2v-jj9q-g3rg
Title: Possible Log Injection in Rack::CommonLogger
Solution: upgrade to '~> 2.2.11', '~> 3.0.12', '>= 3.1.10'

Name: rack
Version: 2.2.10
CVE: CVE-2025-27111
GHSA: GHSA-8cgq-6mh2-7j6v
Criticality: Unknown
URL: https://github.com/rack/rack/security/advisories/GHSA-8cgq-6mh2-7j6v
Title: Escape Sequence Injection vulnerability in Rack lead to Possible Log Injection
Solution: upgrade to '~> 2.2.12', '~> 3.0.13', '>= 3.1.11'

Name: rack
Version: 2.2.10
CVE: CVE-2025-27610
GHSA: GHSA-7wqh-767x-r66v
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-7wqh-767x-r66v
Title: Local File Inclusion in Rack::Static
Solution: upgrade to '~> 2.2.13', '~> 3.0.14', '>= 3.1.12'

Name: rack
Version: 2.2.10
CVE: CVE-2025-32441
GHSA: GHSA-vpfw-47h7-xj4g
Criticality: Medium
URL: https://github.com/rack/rack-session/security/advisories/GHSA-9j94-67jr-4cqj
Title: Rack session gets restored after deletion
Solution: upgrade to '>= 2.2.14'

Name: rack
Version: 2.2.10
CVE: CVE-2025-46727
GHSA: GHSA-gjh7-p2fx-99vx
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-gjh7-p2fx-99vx
Title: Rack has an Unbounded-Parameter DoS in Rack::QueryParser
Solution: upgrade to '~> 2.2.14', '~> 3.0.16', '>= 3.1.14'

Name: thor
Version: 1.3.2
CVE: CVE-2025-54314
GHSA: GHSA-mqcp-p2hv-vw6x
Criticality: Low
URL: https://github.com/advisories/GHSA-mqcp-p2hv-vw6x
Title: Thor can construct an unsafe shell command from library input.
Solution: upgrade to '>= 1.4.0'