### PR TITLE
Update ignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,13 @@
 **/.DS_Store
+.bash_history
 .bundle
+.cache/
 .env*
 .git/
+.local/
 bundle/
 config/database.yml
 config/initializers/local.rb
+docker-compose.yml
 log/
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 /db/*.sqlite3-journal
 
 # Ignore all logfiles and tempfiles.
+.bash_history
+/.cache
+/.local
 /log/*
 !/log/.keep
 /tmp


### PR DESCRIPTION
This PR updates the `.gitignore` and `.dockerignore` files to ignore the following files and directories that may occur locally during development:

* `.bash_history`
* `.cache/`
* `.local/`
* `docker-compose.yml`