### PR TITLE
Create `script/prod_run`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)

--- a/script/_vault
+++ b/script/_vault
@@ -1,0 +1,26 @@
+# HCP Vault helper function for Bash
+
+HASHICORP_VAULT_ADDR="https://hcp-vault-private-vault-fc507e0d.5d5b1f21.z1.hashicorp.cloud:8200"
+HASHICORP_VAULT_NAMESPACE="admin/asr"
+HASHICORP_VAULT_VERSION="1.20-ent"
+
+function vault() {
+  docker run --rm \
+    --env="SKIP_SETCAP=true" \
+    --env="VAULT_ADDR=$HASHICORP_VAULT_ADDR" \
+    --env="VAULT_NAMESPACE=$HASHICORP_VAULT_NAMESPACE" \
+    --pull="always" \
+    --quiet \
+    --user="vault" \
+    --volume="$(pwd):/workdir" \
+    --volume="vault_cli:/home/vault" \
+    --workdir="/workdir" \
+    hashicorp/vault-enterprise:$HASHICORP_VAULT_VERSION "$@"
+}
+
+function vault_saml_login() {
+  TOKEN_LOOKUP=$(vault token lookup 2>&1) || true
+  if [[ "$TOKEN_LOOKUP" =~ "Error" ]]; then
+    vault login -method=saml -no-print=true --namespace=admin
+  fi
+}

--- a/script/prod_run
+++ b/script/prod_run
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# script/prod_run: Run the production Docker container against the staging or production environments.
+
+cd "$(dirname "$0")/.."
+
+CONTAINER_NAME="$(basename $(pwd))"
+DOCKER_REPO_HOSTNAME="asr-docker-local.artifactory.umn.edu"
+IMAGE_NAME="$DOCKER_REPO_HOSTNAME/$CONTAINER_NAME:latest"
+VAULT_APP_NAME="sessions"
+
+if [ $# -eq 0 ]; then
+  echo "Provide an environment: script/prod_run [production|staging]"
+  exit 1
+fi
+
+RAILS_ENV=$1
+
+echo "==> Initializing HCP Vault..."
+source "./script/_vault"
+vault_saml_login
+
+echo "==> Building container for ${IMAGE_NAME}"
+./script/prod_build "$RAILS_ENV"
+
+echo "==> Running container for ${IMAGE_NAME}"
+APP_ROLE_SECRET_PATH="auth/approle/role/app_${VAULT_APP_NAME}_${RAILS_ENV}/secret-id"
+VAULT_WRAPPED_SECRET=$(vault write -f -wrap-ttl=10s -field=wrapping_token "$APP_ROLE_SECRET_PATH")
+docker run \
+  --rm \
+  --name="$CONTAINER_NAME" \
+  --env="RACK_ENV=$RAILS_ENV" \
+  --env="RAILS_ENV=$RAILS_ENV" \
+  --env="VAULT_WRAPPED_SECRET=$VAULT_WRAPPED_SECRET" \
+  --publish="127.0.0.1:3000:3000" \
+  "$IMAGE_NAME"


### PR DESCRIPTION
This PR implements [ClickUp task 86b6609c9](https://app.clickup.com/t/86b6609c9). It creates a `script/prod_run` file that can be used to run the staging/production flavor of the Docker image locally.

The following script was added to help facilitate the use of Vault:

* `script/_vault` - A helper that adds aliases to `vault` and `vault_saml_login` and uses the official HashiCorp Vault enterprise Docker image to run the Vault CLI

To test this new helper, perform the following steps:

1) `script/prod_run staging`
1) Open a web browser and navigate to: `http://localhost:3000/sessions.json`

NOTE: Commenting out `config.force_ssl = true` in the `config/environments/production.rb` was necessary because Puma will attempt to redirect you to an HTTPS endpoint otherwise. For local testing, this does not work because there is no reverse proxy to serve the site over SSL, and the web browser will try to send you to a SSL-enabled URL that doesn't exist. In practice, this is a safe change because Traefik already has rules in place to auto-redirect HTTP requests to HTTPS.