### PR TITLE
Add script to run a production Rails console

### DIFF
--- a/script/prod_rails_console
+++ b/script/prod_rails_console
@@ -11,5 +11,5 @@ if [ $# -eq 0 ]; then
 fi
 
 export ADDITIONAL_DOCKER_FLAGS='-it --env=VAULT_AGENT_COMMAND'
-export VAULT_AGENT_COMMAND='["bin/rails", "console"]'
+export VAULT_AGENT_COMMAND='["bin/rails", "console", "--sandbox"]'
 ./script/prod_run $1

--- a/script/prod_rails_console
+++ b/script/prod_rails_console
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# script/prod_rails_console: Run a Rails console against the staging or production environments.
+
+cd "$(dirname "$0")/.."
+
+if [ $# -eq 0 ]; then
+  echo "Provide an environment: script/prod_rails_console [production|staging]"
+  exit 1
+fi
+
+export ADDITIONAL_DOCKER_FLAGS='-it --env=VAULT_AGENT_COMMAND'
+export VAULT_AGENT_COMMAND='["bin/rails", "console"]'
+./script/prod_run $1

--- a/script/prod_run
+++ b/script/prod_run
@@ -5,6 +5,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+ADDITIONAL_DOCKER_FLAGS="${ADDITIONAL_DOCKER_FLAGS:-}"
 CONTAINER_NAME="$(basename $(pwd))"
 DOCKER_REPO_HOSTNAME="asr-docker-local.artifactory.umn.edu"
 IMAGE_NAME="$DOCKER_REPO_HOSTNAME/$CONTAINER_NAME:latest"
@@ -28,7 +29,7 @@ echo "==> Running container for ${IMAGE_NAME}"
 APP_ROLE_SECRET_PATH="auth/approle/role/app_${VAULT_APP_NAME}_${RAILS_ENV}/secret-id"
 VAULT_WRAPPED_SECRET=$(vault write -f -wrap-ttl=10s -field=wrapping_token "$APP_ROLE_SECRET_PATH")
 docker run \
-  --rm \
+  --rm $ADDITIONAL_DOCKER_FLAGS \
   --name="$CONTAINER_NAME" \
   --env="RACK_ENV=$RAILS_ENV" \
   --env="RAILS_ENV=$RAILS_ENV" \


### PR DESCRIPTION
This PR implements [ClickUp task 86b6609rz](https://app.clickup.com/t/86b6609rz). It adds a `script/prod_rails_console` helper that can be used to launch `bin/rails console` using the production Docker image with a local container.

The script runs `bin/rails console` against staging or production depending on the environment that is provided. It does this by running Vault Agent and overriding the `VAULT_AGENT_COMMAND` environment variable. An environment variable `ADDITIONAL_DOCKER_FLAGS` was also added to `script/prod_run` to allow dynamic injection of additional Docker options.

This new script is used the same way as `script/prod_run` by specifying the environment after the command. For example, the following command will open a Rails console against the staging environment:

`script/prod_rails_console staging`